### PR TITLE
Add CV upload and summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# AI_Resume_maker
+# AI Resume Optimizer
+
+Detta är en enkel Streamlit-app som genererar ett CV baserat på en jobbannons och dina egna uppgifter. Nu går det även att ladda upp ditt befintliga CV (PDF) för att skapa en kort sammanfattning som kan användas i prompten.
+
+## Kom igång
+
+1. Installera beroenden
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Skapa en `secrets.toml` med din Hugging Face-token:
+   ```toml
+   HF_API_TOKEN = "din-token-här"
+   ```
+3. Starta applikationen:
+   ```bash
+   streamlit run app.py
+   ```
+
+## Användning
+
+1. Fyll i formulären med jobbannons, namn, roll, kompetenser och prestationer.
+2. Ladda upp ett befintligt CV i PDF-format och klicka på **Sammanfatta CV** för att låta modellen skapa en kort summering.
+3. Markera om du vill använda sammanfattningen i prompten och klicka sedan på **Generera CV**.
+
+Det genererade CV:t visas i ren text och kan kopieras direkt.

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import requests
+import fitz  # PyMuPDF for reading PDFs
 
 # Sidinställningar
 st.set_page_config(page_title="AI Resume Optimizer", layout="centered")
@@ -14,13 +15,46 @@ role = st.text_input("🎓 Din nuvarande roll")
 skills = st.text_area("🛠️ Vad är du bra på?")
 achievements = st.text_area("🏆 Vad är du mest stolt över?")
 
+# Ladda upp befintligt CV
+cv_file = st.file_uploader("📑 Ladda upp ditt nuvarande CV (PDF)", type="pdf")
+cv_summary = ""
+
+# Läs texten från PDF och skapa en sammanfattning
+def read_pdf(file) -> str:
+    try:
+        with fitz.open(stream=file.read(), filetype="pdf") as doc:
+            text = "\n".join(page.get_text() for page in doc)
+        return text
+    except Exception as e:
+        st.error(f"Kunde inte läsa PDF: {e}")
+        return ""
+
+def summarize_cv(text: str) -> str:
+    summary_prompt = f"Sammanfatta följande CV i punktform:\n\n{text}"
+    return call_llama3(summary_prompt)
+
+if 'cv_summary' not in st.session_state:
+    st.session_state['cv_summary'] = ''
+
+if cv_file and st.button("📝 Sammanfatta CV"):
+    with st.spinner("Läser och sammanfattar CV..."):
+        cv_text = read_pdf(cv_file)
+        if cv_text:
+            st.session_state['cv_summary'] = summarize_cv(cv_text)
+
+use_summary = False
+if st.session_state['cv_summary']:
+    st.markdown("### Sammanfattning av uppladdat CV")
+    st.text_area("Kontrollera sammanfattningen", st.session_state['cv_summary'], height=150)
+    use_summary = st.checkbox("Använd denna sammanfattning i prompten", value=True)
+
 # Funktion för att anropa Hugging Face LLaMA 3 API
 def call_llama3(prompt):
     url = "https://api-inference.huggingface.co/models/HuggingFaceH4/zephyr-7b-beta"
     headers = {
         "Authorization": f"Bearer {st.secrets['HF_API_TOKEN']}"
     }
-    response = requests.post(url, headers=headers, json={"inputs": prompt})
+    response = requests.post(url, headers=headers, json={"inputs": prompt}, timeout=30)
 
     if response.status_code == 200:
         try:
@@ -33,6 +67,7 @@ def call_llama3(prompt):
 # När användaren klickar på knappen
 if st.button("🚀 Generera CV"):
     with st.spinner("AI jobbar..."):
+        summary_section = f"Sammanfattning av tidigare CV:\n{st.session_state['cv_summary']}\n" if use_summary else ""
 
         # Prompten till modellen
         prompt = f'''Du är en professionell CV-skapare. Använd informationen nedan för att skriva ett CV enligt den här mallen:
@@ -58,6 +93,7 @@ INFORMATION FRÅN ANVÄNDAREN:
 Jobbannons: {job_text}
 Kompetenser: {skills}
 Prestationer: {achievements}
+{summary_section}
 
 Skriv CV:t i ren text enligt formatet ovan. Använd bara svenska.
 '''
@@ -66,12 +102,6 @@ Skriv CV:t i ren text enligt formatet ovan. Använd bara svenska.
         generated_cv = call_llama3(prompt)
 
         # Visa resultat
-        st.success("✅ CV genererat!")
-        st.markdown("### ✨ Ditt genererade CV:")
-        st.code(generated_cv, language='markdown')
-
-
-
         st.success("✅ CV genererat!")
         st.markdown("### ✨ Ditt genererade CV:")
         st.code(generated_cv, language='markdown')


### PR DESCRIPTION
## Summary
- allow uploading an existing CV as PDF
- parse PDF with PyMuPDF and summarize it via the Hugging Face API
- include optional CV summary in the final prompt
- remove duplicate output lines and add request timeout
- expand README with setup and usage instructions

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857c810891483278b4998b77ab5c452