### PR TITLE
Add timeout handling for llama3 API call

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,7 +20,15 @@ def call_llama3(prompt):
     headers = {
         "Authorization": f"Bearer {st.secrets['HF_API_TOKEN']}"
     }
-    response = requests.post(url, headers=headers, json={"inputs": prompt})
+    try:
+        response = requests.post(
+            url,
+            headers=headers,
+            json={"inputs": prompt},
+            timeout=30,
+        )
+    except requests.Timeout:
+        return "⌛ Förfrågan till AI-modellen tog för lång tid. Försök igen senare."
 
     if response.status_code == 200:
         try:


### PR DESCRIPTION
## Summary
- add timeout parameter when requesting the LLaMA API
- catch `requests.Timeout` and inform the user

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6857c9014e5c8327bf73553a65de24f2